### PR TITLE
Upgrade kotest from 4.2.0.RC2 to 4.2.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -12,6 +12,6 @@ plugin.org.danilopianini.publish-on-central=0.2.0
 
 plugin.org.jetbrains.dokka=0.9.18
 
-version.kotest=4.2.0.RC2
+version.kotest=4.2.0
 
 version.kotlin=1.3.50


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.