### PR TITLE
Upgrade dokka from 0.9.18 to 0.10.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -11,7 +11,7 @@ plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 
 plugin.org.danilopianini.publish-on-central=0.2.0
 
-plugin.org.jetbrains.dokka=0.9.18
+plugin.org.jetbrains.dokka=0.10.1
 
 version.kotest=4.2.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.