### PR TITLE
Upgrade dokka from 1.4.0-rc to 1.4.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -11,7 +11,7 @@ plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 
 plugin.org.danilopianini.publish-on-central=0.3.0-rc1
 
-plugin.org.jetbrains.dokka=1.4.0-rc
+plugin.org.jetbrains.dokka=1.4.0
 
 version.kotest=4.2.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.