### PR TITLE
Upgrade Gradle Wrapper to 7.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,9 @@ tasks.withType<KotlinCompile> {
 }
 
 tasks {
+    withType<Copy> {
+        duplicatesStrategy = org.gradle.api.file.DuplicatesStrategy.WARN
+    }
     "test"(Test::class) {
         useJUnitPlatform()
         testLogging.showStandardStreams = true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request upgrades the Gradle wrapper in project 
from 6.8.3 to 7.0.                       