### PR TITLE
Upgrade kotest from 4.5.0 to 4.6.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -13,6 +13,6 @@ plugin.org.danilopianini.publish-on-central=0.5.0
 
 plugin.org.jetbrains.dokka=1.5.0
 
-version.kotest=4.5.0
+version.kotest=4.6.0
 
 version.kotlin=1.4.32


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.